### PR TITLE
WIP: Support Jlink debug probe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(UNIX)
     find_package(libusb REQUIRED)
     find_package(glfw3 REQUIRED)
     set(STLINK_LINUX ${CMAKE_CURRENT_SOURCE_DIR}/third_party/stlink/lib/linux/libstlink.a)
-    set(SPDLOG_LINUX ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/lib/linux/libspdlog.so.1.11.0)
+#    set(SPDLOG_LINUX ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/lib/linux/libspdlog.so.1.11.0)
     set(INSTALL_PATH /usr/local/STMViewer)
     set(DESKTOP_FILE_PATH /usr/share/applications)
 endif()
@@ -72,7 +72,7 @@ set(PROJECT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gui/GuiSwoPlots.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Gui/GuiSwoControl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/TargetMemoryHandler/TargetMemoryHandler.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/src/TargetMemoryHandler/StlinkHandler.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/TargetMemoryHandler/JlinkHandler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Plot/Plot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/Variable/Variable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ConfigHandler/ConfigHandler.cpp

--- a/src/PlotHandler/PlotHandler.cpp
+++ b/src/PlotHandler/PlotHandler.cpp
@@ -6,7 +6,7 @@
 PlotHandler::PlotHandler(std::atomic<bool>& done, std::mutex* mtx, std::shared_ptr<spdlog::logger> logger) : PlotHandlerBase(done, mtx, logger)
 {
 	dataHandle = std::thread(&PlotHandler::dataHandler, this);
-	stlinkReader = std::make_unique<StlinkHandler>();
+	stlinkReader = std::make_unique<JlinkHandler>();
 	varReader = std::make_unique<TargetMemoryHandler>(stlinkReader.get(), logger);
 }
 PlotHandler::~PlotHandler()

--- a/src/PlotHandler/PlotHandler.hpp
+++ b/src/PlotHandler/PlotHandler.hpp
@@ -9,7 +9,8 @@
 #include "Plot.hpp"
 #include "PlotHandlerBase.hpp"
 #include "ScrollingBuffer.hpp"
-#include "StlinkHandler.hpp"
+//#include "StlinkHandler.hpp"
+#include "JlinkHandler.h"
 #include "TargetMemoryHandler.hpp"
 #include "spdlog/spdlog.h"
 
@@ -36,7 +37,7 @@ class PlotHandler : public PlotHandlerBase
 	void dataHandler();
 
    private:
-	std::unique_ptr<StlinkHandler> stlinkReader;
+	std::unique_ptr<JlinkHandler> stlinkReader;
 	std::unique_ptr<TargetMemoryHandler> varReader;
 	std::chrono::time_point<std::chrono::steady_clock> start;
 	Settings settings{};

--- a/src/TargetMemoryHandler/ITargetMemoryHandler.hpp
+++ b/src/TargetMemoryHandler/ITargetMemoryHandler.hpp
@@ -2,6 +2,7 @@
 #define _IVARIABLEREADER_HPP
 
 #include <string>
+#include <cstdint>
 
 class ITargetMemoryHandler
 {

--- a/src/TargetMemoryHandler/JlinkHandler.cpp
+++ b/src/TargetMemoryHandler/JlinkHandler.cpp
@@ -1,0 +1,87 @@
+#include "JlinkHandler.h"
+
+#include <dlfcn.h>
+#include <spdlog/fmt/bin_to_hex.h>
+#include <spdlog/spdlog.h>
+
+
+JlinkHandler::JlinkHandler()
+{
+	int ret;
+	so_handle = dlopen("/opt/SEGGER/JLink/libjlinkarm.so", RTLD_NOW);
+
+	jlink_select_by_usb = (jlink_select_by_usb_t)dlsym(so_handle, "JLINKARM_EMU_SelectByUSBSN");
+	jlink_lock = (jlink_lock_t)dlsym(so_handle, "JLock");
+	jlink_open = (jlink_open_t)dlsym(so_handle, "JLINKARM_OpenEx");
+	jlink_is_open = (jlink_is_open_t)dlsym(so_handle, "JLINKARM_IsOpen");
+	jlink_read_mem = (jlink_read_mem_t)dlsym(so_handle, "JLINKARM_ReadMemEx");
+
+	// Following connection path from function `open`: https://github.com/square/pylink/blob/master/pylink/jlink.py#L681k
+	ret = jlink_select_by_usb(440237411);
+	spdlog::info("Select result {}", ret);
+	if (ret < 0)
+	{
+		return;
+	}
+
+	// Creates sig SEGV -> wrong parameter?
+	//	ret = jlink_lock(440237411);
+	//	spdlog::info("Loc result {}", ret);
+	//	if (ret < 0) {
+	//		return;
+	//	}
+
+	ret = jlink_open(nullptr, nullptr);
+	spdlog::info("Opening JLink {}", ret);
+
+	ret = jlink_is_open();
+	spdlog::info("Is open JLink {}", ret);
+}
+
+bool JlinkHandler::startAcqusition()
+{
+	bool ret;
+	ret = jlink_is_open();
+	spdlog::info("Is open JLink {}", ret);
+
+	return ret;
+}
+bool JlinkHandler::stopAcqusition()
+{
+	// TODO
+	return true;
+}
+bool JlinkHandler::isValid() const
+{
+	// TODO
+	return true;
+}
+
+bool JlinkHandler::readMemory(uint32_t address, uint32_t* value)
+{
+	uint8_t buf[4] = {0};
+	int count;
+
+	count = jlink_read_mem(address, 4, buf, nullptr);
+	spdlog::debug("Read {} bytes", count);
+	if (count <= 0)
+	{
+		return false;
+	}
+
+	spdlog::debug("Value {}", *(uint32_t * )buf);
+
+	*value = *(uint32_t * )buf;
+	return true;
+}
+bool JlinkHandler::writeMemory(uint32_t address, uint8_t* buf, uint32_t len)
+{
+	// TODO
+	return false;
+}
+
+std::string JlinkHandler::getLastErrorMsg() const
+{
+	//	return lastErrorMsg;
+	return "TODO";
+}

--- a/src/TargetMemoryHandler/JlinkHandler.h
+++ b/src/TargetMemoryHandler/JlinkHandler.h
@@ -1,0 +1,38 @@
+#ifndef STMVIEWER_JLINKHANDLER_H
+#define STMVIEWER_JLINKHANDLER_H
+
+#include "ITargetMemoryHandler.hpp"
+
+typedef int (*jlink_select_by_usb_t)(int);
+typedef int (*jlink_lock_t)(int);
+// Open takes a log and error handler as inputs
+typedef int (*jlink_open_t)(void*, void*);
+typedef bool (*jlink_is_open_t)();
+
+// Addr, buf_size, buf, access
+// https://github.com/square/pylink/blob/master/pylink/jlink.py#L2936
+typedef bool (*jlink_read_mem_t)(uint32_t, int32_t size, uint8_t*, void*);
+
+class JlinkHandler : public ITargetMemoryHandler
+{
+   public:
+	JlinkHandler();
+	bool startAcqusition() override;
+	bool stopAcqusition() override;
+	bool isValid() const override;
+
+	bool readMemory(uint32_t address, uint32_t* value) override;
+	bool writeMemory(uint32_t address, uint8_t* buf, uint32_t len) override;
+
+	std::string getLastErrorMsg() const override;
+
+   private:
+	void* so_handle;
+	jlink_select_by_usb_t jlink_select_by_usb;
+	jlink_lock_t jlink_lock;
+	jlink_open_t jlink_open;
+	jlink_is_open_t jlink_is_open;
+	jlink_read_mem_t jlink_read_mem;
+};
+
+#endif	// STMVIEWER_JLINKHANDLER_H

--- a/src/Variable/Variable.hpp
+++ b/src/Variable/Variable.hpp
@@ -2,6 +2,7 @@
 #define __VARIABLE_HPP
 
 #include <string>
+#include <cstdint>
 class Variable
 {
    public:

--- a/src/gitversion.hpp
+++ b/src/gitversion.hpp
@@ -1,1 +1,1 @@
-static const char* GIT_HASH = "66545e48b29d40ff0217294e9ff19dd7d612de25";
+static const char* GIT_HASH = "4ee85552d1f51cd0c9ba6f5eca58f9c9a4d09d59";


### PR DESCRIPTION
Closes #22 

This is only a WIP prototype of reading memory from Jlink debug probe.

This PR add a JLinkHandler to this great project.

It uses the shared library supplied by Segger to access a Jlink debug Probe.
Since there are no open source headers it is inspired by [pylink](https://github.com/square/pylink).

Known issues:
* Only works on Linux for the default installation of libjlinkarm.so
* Selects the USB ID of my debug Probe that is on my table
* When clicking the start a J-Link warning pops up that no device was specified (Image 1)
  * After that a device selection appears -> The connected MCU has to be in this list
* Missing functions: write, get last error message, start acquisition, stop acquisition


There is also some changes in here that were required to build this tool on my machine (Manjaro Linux):
* Install GLFW with package manager
* Install SPDLOG with package manager (X11 version)
  * Remove the SPDLOG library from CMakeLists.tx
* Include <cstdint.h> in some files because <string> was not enough for uint*_t

Image 1 (J-Link warning)
![image](https://github.com/klonyyy/STMViewer/assets/56924345/8c8dd3f5-72a6-4179-a91c-5fd1d0e12fc4)

Image 2 (Showcase working prototype for 500ms counter)
![image](https://github.com/klonyyy/STMViewer/assets/56924345/b2c7d940-c715-4193-8e8f-40b99bccf14e)
