### PR TITLE
Bugfix/st link wfi read

### DIFF
--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -315,7 +315,7 @@ void Gui::drawDebugProbes()
 		shouldListDevices = false;
 	}
 
-	if (plotHandler->probeSettings.debugProbe == 1)
+	if (plotHandler->probeSettings.debugProbe == 1)	// If JLink
 	{
 		ImGui::Text("Target name    ");
 		ImGui::SameLine();
@@ -337,6 +337,12 @@ void Gui::drawDebugProbes()
 
 		ImGui::SameLine();
 		ImGui::HelpMarker("Select normal or high speed sampling (HSS) mode");
+	} else {	// If STLink
+		ImGui::Text("Read in sleep (WFI):");
+		ImGui::SameLine();
+		ImGui::HelpMarker("It will wakeup the core on every read. Be careful if your application logic depends on time spent in sleep mode.");
+		ImGui::SameLine();
+		ImGui::Checkbox("##ReadSleep", &debugProbeDevice->isReadWhileSleepAllowed);
 	}
 
 	ImGui::EndDisabled();

--- a/src/TargetMemoryHandler/IDebugProbe.hpp
+++ b/src/TargetMemoryHandler/IDebugProbe.hpp
@@ -19,6 +19,9 @@ class IDebugProbe
 		HSS = 1,
 	};
 
+	// Enable read while sleep (WFI) mode
+	bool isReadWhileSleepAllowed = false;
+
 	/* timestamp (first) and a map of <address-value> entries (second) only fo HSS mode */
 	using varEntryType = std::pair<double, std::unordered_map<uint32_t, double>>;
 

--- a/src/TargetMemoryHandler/StlinkHandler.cpp
+++ b/src/TargetMemoryHandler/StlinkHandler.cpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "logging.h"
+#include "register.h"
 
 StlinkHandler::StlinkHandler(spdlog::logger* logger) : logger(logger)
 {
@@ -50,11 +51,110 @@ std::optional<IDebugProbe::varEntryType> StlinkHandler::readSingleEntry()
 	return std::nullopt;
 }
 
+int StlinkHandler::IsChipHalted(stlink_t* sl)
+{
+	uint32_t dhcsr = 0;
+	bool isError = stlink_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr) != 0;
+
+	if (isError) {
+		logger->error("Error while reading DHCSR register");
+		return -1;
+	} else {
+		if ((dhcsr & STLINK_REG_DHCSR_S_HALT) != 0) {
+			return 1;
+		} else {
+			return 0;
+		}
+	}
+}
+
+int StlinkHandler::IsChipSleeping(stlink_t* sl)
+{
+	uint32_t dhcsr = 0;
+	bool isError = stlink_read_debug32(sl, STLINK_REG_DHCSR, &dhcsr) != 0;
+
+	if (isError) {
+		logger->error("Error while reading DHCSR register");
+		return -1;
+	} else {
+		if ((dhcsr & STLINK_REG_DHCSR_S_SLEEP) != 0) {
+			return 1;
+		} else {
+			return 0;
+		}
+	}
+}
+
+bool StlinkHandler::IsWaitForWakeSuccess(stlink_t* sl)
+{
+	int timeout = 1000;
+	int sleep = -1;
+	int halt = -1;
+
+	while (timeout-- > 0) {
+		sleep = IsChipSleeping(sl);
+		halt = IsChipHalted(sl);
+
+		if (sleep == 0 && halt == 1) {
+			return true;
+		}
+	}
+	return false;
+}
+
+bool StlinkHandler::IsWaitForResumeSuccess(stlink_t* sl)
+{
+	int timeout = 1000;
+	int halt = -1;
+
+	while (timeout-- > 0) {
+		halt = IsChipHalted(sl);
+
+		if (halt == 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
 bool StlinkHandler::readMemory(uint32_t address, uint32_t* value)
 {
 	if (!isRunning)
 		return false;
-	return stlink_read_debug32(sl, address, value) == 0;
+
+	bool result = true;
+
+	// Check if the chip is sleeping
+	int wasSleeping = IsChipSleeping(sl);
+	if (wasSleeping == 0)
+		// Try to read the memory
+		result &= stlink_read_debug32(sl, address, value) == 0;
+	else if (wasSleeping == -1)
+		return false;
+	else
+		*value = 0;	// In case when read in sleep not allowed, return 0 when chip is sleeping
+
+	if (isReadWhileSleepAllowed) {
+		// If the chip entered sleep during read operation, we need to wake it up and retry read
+		int isSleeping = IsChipSleeping(sl);
+		if (isSleeping == 1 || wasSleeping == 1) {
+			// Halt the chip to wake it up
+			result &= stlink_write_debug32(sl, STLINK_REG_DHCSR, STLINK_REG_DHCSR_DBGKEY | STLINK_REG_DHCSR_C_DEBUGEN | STLINK_REG_DHCSR_C_HALT) == 0;
+			// Wait for the chip to halt and wake up
+			result &= IsWaitForWakeSuccess(sl);
+			// Retry read
+			result &= stlink_read_debug32(sl, address, value) == 0;
+			// Resume the chip
+			result &= stlink_write_debug32(sl, STLINK_REG_DHCSR, STLINK_REG_DHCSR_DBGKEY | STLINK_REG_DHCSR_C_DEBUGEN) == 0;
+			// Wait for the chip to resume
+			result &= IsWaitForResumeSuccess(sl);
+			// TODO: Find a way to return chip into sleep mode (and make sure that no interrupts are generated during this read operation)
+		} else if (isSleeping == -1) {
+			return false;
+		}
+	}
+	
+	return result;
 }
 bool StlinkHandler::writeMemory(uint32_t address, uint8_t* buf, uint32_t len)
 {

--- a/src/TargetMemoryHandler/StlinkHandler.hpp
+++ b/src/TargetMemoryHandler/StlinkHandler.hpp
@@ -28,6 +28,10 @@ class StlinkHandler : public IDebugProbe
 	}
 
    private:
+	int IsChipHalted(stlink_t* sl);
+	int IsChipSleeping(stlink_t* sl);
+	bool IsWaitForWakeSuccess(stlink_t* sl);
+	bool IsWaitForResumeSuccess(stlink_t* sl);
 	stlink_t* sl = nullptr;
 	bool isRunning = false;
 	std::string lastErrorMsg = "";


### PR DESCRIPTION
Fixed STLink read while core is in WFI sleep.
Added checkbox to enable this feature.
In case when checkbox set - STLink wakes up core and read value instead of returning 0.
When core is in WFI and checkbox not set, read operation always returns 0.