### PR TITLE
Make elf path relative to project file

### DIFF
--- a/src/Gui/Gui.cpp
+++ b/src/Gui/Gui.cpp
@@ -480,7 +480,7 @@ void Gui::drawUpdateAddressesFromElf()
 	if (ImGui::Button(buttonText, ImVec2(-1, 25 * contentScale)) || performVariablesUpdate)
 	{
 		lastModifiedTime = std::filesystem::file_time_type::clock::now();
-		refreshThread = std::async(std::launch::async, &GdbParser::updateVariableMap2, parser, projectElfPath, std::ref(vars));
+		refreshThread = std::async(std::launch::async, &GdbParser::updateVariableMap2, parser, this->convertProjectPathToAbsolute(projectElfPath), std::ref(vars));
 		performVariablesUpdate = false;
 	}
 
@@ -1162,11 +1162,30 @@ bool Gui::openElfFile()
 
 	if (path != "")
 	{
-		projectElfPath = path;
+		std::filesystem::path relPath = std::filesystem::relative(path, std::filesystem::path(projectConfigPath).parent_path());
+        projectElfPath = relPath.string();
 		logger->info("Project elf file path: {}", projectElfPath);
 		return true;
 	}
 	return false;
+}
+
+std::string Gui::convertProjectPathToAbsolute(const std::string& relativePath)
+{	
+	if (relativePath.empty())
+		return "";
+
+	try
+	{
+        // Convert relative path to absolute path based on project file location
+        std::filesystem::path absPath = std::filesystem::absolute(std::filesystem::path(projectConfigPath).parent_path() / relativePath);
+        return absPath.string();
+    }
+    catch (std::filesystem::filesystem_error& e)
+    {
+        logger->error("Failed to convert path to absolute: {}", e.what());
+        return "";
+    }
 }
 
 void Gui::checkShortcuts()
@@ -1188,10 +1207,10 @@ void Gui::checkShortcuts()
 
 bool Gui::checkElfFileChanged()
 {
-	if (!std::filesystem::exists(projectElfPath))
+	if (!std::filesystem::exists(convertProjectPathToAbsolute(projectElfPath)))
 		return false;
 
-	auto writeTime = std::filesystem::last_write_time(projectElfPath);
+	auto writeTime = std::filesystem::last_write_time(convertProjectPathToAbsolute(projectElfPath));
 	return writeTime > lastModifiedTime;
 }
 

--- a/src/Gui/Gui.hpp
+++ b/src/Gui/Gui.hpp
@@ -106,6 +106,7 @@ class Gui
 	void showChangeFormatPopup(const char* text, Plot& plt, const std::string& name);
 	bool openProject();
 	bool openElfFile();
+	std::string convertProjectPathToAbsolute(const std::string& projectRelativePath);
 	void checkShortcuts();
 	bool checkElfFileChanged();
 

--- a/src/Gui/GuiImportVariables.cpp
+++ b/src/Gui/GuiImportVariables.cpp
@@ -39,7 +39,7 @@ void Gui::drawImportVariablesWindow()
 
 		if (ImGui::Button(buttonText, ImVec2(-1, 25 * contentScale)) || shouldUpdateOnOpen)
 		{
-			refreshThread = std::async(std::launch::async, &GdbParser::parse, parser, projectElfPath);
+			refreshThread = std::async(std::launch::async, &GdbParser::parse, parser, convertProjectPathToAbsolute(projectElfPath));
 			shouldUpdateOnOpen = false;
 		}
 


### PR DESCRIPTION
Make elf path relative to project config file. It does the following:
- converts to relative path after picking the elf file
- converts to absolute when using the path
- can use absolute path if it was manually typed or stored in config

Solves #65